### PR TITLE
Updated android-permission maven repo.

### DIFF
--- a/VERSIONS.gradle
+++ b/VERSIONS.gradle
@@ -140,7 +140,7 @@ ext {
 
     libs = [
         reactNative: [group: 'com.facebook.react', name: 'react-native', version: getReactNativeLibVersion()],
-        permissions: [group: 'com.intentfilter', name: 'android-permissions', version: '0.1.7'],
+        permissions: [group: 'io.github.nishkarsh', name: 'android-permissions', version: '0.1.7'],
         logback: [group: 'com.github.tony19', name: 'logback-android', version: '1.1.1-9'],
         slf4j: [group: 'org.slf4j', name: 'slf4j-api', version: '1.7.21'],
         promise: [group: 'com.github.jparkie', name: 'promise', version: '1.0.3'],


### PR DESCRIPTION
Issue faced
https://github.com/mauron85/react-native-background-geolocation/issues/551

Here in this discussion they have moved the android-permissions.
https://github.com/nishkarsh/android-permissions/issues/20

Replacing the com.intentfilter to io.github.nishkarsh fixed the issue.